### PR TITLE
#10 removing event on load and allowing users to set create options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ There are three options available for Google Analytics you may want to use in yo
 * `LOG_PAGEVIEW` (boolean) - Logs all `pageview` events to the console.
 * `LOG_EVENTS` (boolean) - Logs all `event`, `timing` and `network` (social) requests to the console.
 * `onload` (boolean) - Lazy loads Google Analytics after the `window.onload` function fires.
-
-These options allow you to ensure your events are being fired.
+* `createOptions` (object) - This will get `JSON.stringify` encoded and passed to the create object as the last parameter.
 
 ## Configuring Tealium IQ
 

--- a/index.js
+++ b/index.js
@@ -38,20 +38,22 @@ module.exports = {
 		}
 
 		const trackingId = analyticsSettings.trackingId,
-			onload = Boolean(analyticsSettings.onload);
+			onload = Boolean(analyticsSettings.onload),
+			options = analyticsSettings.createOptions,
+			createOptions = options ? `,${JSON.stringify(options)}` : '';
 
 		text = `Including Google Analytics (${trackingId}`;
 		text += (onload ? ' on load' : '') + ')';
 		this.ui.writeLine(text);
 
 		if (onload) {
-			script += 'window.addEventListener("load",function(){';
+			script += 'window.addEventListener("load",function et_RmGa(){';
 		}
 
-		script += `(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create','${trackingId}','auto');`;
+		script += `(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create','${trackingId}'${createOptions});`;
 
 		if (onload) {
-			script += "});";
+			script += "window.removeEventListener('load',et_RmGa,false);},false);";
 		}
 
 		return `<script>${script}</script>`;

--- a/tests/dummy/app/templates/google-analytics.hbs
+++ b/tests/dummy/app/templates/google-analytics.hbs
@@ -43,6 +43,9 @@ module.exports = function(environment) {
 		<li><code>LOG_PAGEVIEW</code> (boolean) - Logs all <code>pageview</code> events to the console.</li>
 		<li><code>LOG_EVENTS</code> (boolean) - Logs all <code>event</code>, <code>timing</code> and <code>network</code> (social) requests to the console.</li>
 		<li><code>onload</code> (boolean) - Lazy loads GoogleAnalytics after the <code>window.onload</code> event fires. It uses <code>addEventListener</code> which requires >= IE9.</li>
+		<li>
+			<code>createOptions</code> (object) - Adds create options to your <code>ga('create', 'UA-####', { ..options..})</code> call. This object will be encoded through <code>JSON.stringify</code>.
+		</li>
 	</ul>
 </p>
 <p>


### PR DESCRIPTION
This removes the event on load to free memory.
This allows users to add create options to the ga('create', '###');